### PR TITLE
Fix bug with longer tag names

### DIFF
--- a/lib/message_format/parser.rb
+++ b/lib/message_format/parser.rb
@@ -155,7 +155,7 @@ module MessageFormat
             raise_expected(id, close_tag, 'Mismatched opening and closing tags')
           end
 
-          @index += id.length
+          @index += 1
           break
         end
         text = parse_text(parent_type)
@@ -168,7 +168,8 @@ module MessageFormat
           if close_tag != id
             raise_expected(id, close_tag, 'Mismatched opening and closing tags')
           end
-          @index += id.length
+
+          @index += 1
           break
         end
         elements.push(parse_argument(parent_type))

--- a/spec/message_format_spec.rb
+++ b/spec/message_format_spec.rb
@@ -134,6 +134,17 @@ describe MessageFormat do
       expect(message).to eql('Simple string with <a>#</a>')
     end
 
+    it 'formats longer tag names correctly' do
+      pattern = 'Long tag name with content after <SPAN>test</SPAN> more content here'
+      message = MessageFormat.new(pattern, 'en-US').format(
+        {
+          SPAN: lambda { |content| "<span class=\"hidden-xs-down\">#{content}</span>" }
+        }
+      )
+
+      expect(message).to eql('Long tag name with content after <span class="hidden-xs-down">test</span> more content here')
+    end
+
     it 'handles pattern with escaped text' do
       pattern = 'This isn\'\'t a \'{\'\'simple\'\'}\' \'string\''
       message = MessageFormat.new(pattern, 'en-US').format()


### PR DESCRIPTION
Found this bug when doing the PR to pull the new gem into elaine. Longer tag names were consuming extra characters after the closing tag.