### PR TITLE
Fix handling > in text in tag

### DIFF
--- a/lib/message_format/parser.rb
+++ b/lib/message_format/parser.rb
@@ -76,7 +76,6 @@ module MessageFormat
           char == '{' or
           char == '}' or
           char == '<' or
-          char == '>' or
           (is_hash_special and char == '#') or
           (is_arg_style and is_whitespace(char))
         )

--- a/spec/message_format_spec.rb
+++ b/spec/message_format_spec.rb
@@ -112,7 +112,7 @@ describe MessageFormat do
       expect(message).to eql('You have {}1,000{} Messages')
     end
 
-    it 'formats self closing tags' do 
+    it 'formats self closing tags' do
       pattern = 'Simple string with <A />'
       message = MessageFormat.new(pattern, 'en-US').format(
         {
@@ -123,7 +123,7 @@ describe MessageFormat do
       expect(message).to eql('Simple string with <hr />')
     end
 
-    it 'formats correctly with hash' do 
+    it 'formats correctly with hash' do
       pattern = 'Simple string with <A>#</A>'
       message = MessageFormat.new(pattern, 'en-US').format(
         {
@@ -143,6 +143,17 @@ describe MessageFormat do
       )
 
       expect(message).to eql('Long tag name with content after <span class="hidden-xs-down">test</span> more content here')
+    end
+
+    it 'formats tag with > in text' do
+      pattern = '<ContentOptionsLink>Settings > Content Options.</ContentOptionsLink>'
+      message = MessageFormat.new(pattern, 'en-US').format(
+        {
+          ContentOptionsLink: lambda { |content| "<a href=\"https://google.com\">#{content}</a>" }
+        }
+      )
+
+      expect(message).to eql('<a href="https://google.com">Settings > Content Options.</a>')
     end
 
     it 'handles pattern with escaped text' do


### PR DESCRIPTION
Asana Task: **https://app.asana.com/0/1202700403502936/1204082510877717/f**

Strings can still have the `>` character in them. This matches the behavior of the format js library. Both the format JS and the code I have been updating here will not handle `<` as it thinks that is the start of a tag and we will have to use `&lt;` in place of it. 